### PR TITLE
instrumentstudio-plugins: Add a .editorconfig file to control indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# Top-most EditorConfig file
+root = true
+
+# All files (can override by exception)
+[*]
+indent_style = space
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# C# files
+[*.cs]
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+insert_final_newline = true
+indent_size = 4


### PR DESCRIPTION
# Justification

This codebase uses spaces for indentation, but Visual Studio uses tabs by default.

# Implementation

Add a `.editorconfig` file specifying indentation settings.

Note: our internal repo's `.editorconfig` file has a lot of other style settings that I didn't copy to this one.

# Testing

I edited some `.csproj` files and Visual Studio used the correct indentation.